### PR TITLE
Update Mono.Cecil to version 0.11.3

### DIFF
--- a/src/IgnoresAccessChecksToGenerator.Tasks/IgnoresAccessChecksToGenerator.Tasks.csproj
+++ b/src/IgnoresAccessChecksToGenerator.Tasks/IgnoresAccessChecksToGenerator.Tasks.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.3" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.1012" />
   </ItemGroup>
 


### PR DESCRIPTION
Updating to Mono.Cecil 0.11.3 also implies updating the target  framework of the MSBuild task to .NET Standard 2.0

This fixes the following issue:

```
IgnoresAccessChecksToGenerator.targets(12, 5): [MSB4018] The "PublicizeInternals" task failed unexpectedly.
System.ArgumentOutOfRangeException: Non-negative number required.
Parameter name: count
   at System.IO.BinaryReader.ReadBytes(Int32 count)
   at Mono.Cecil.PE.ImageReader.ReadDebugHeader()
   at Mono.Cecil.PE.ImageReader.ReadImage()
   at Mono.Cecil.PE.ImageReader.ReadImage(Disposable`1 stream, String file_name)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters)
   at IgnoresAccessChecksToGenerator.Tasks.PublicizeInternals.CreatePublicAssembly(String source, String target)
   at IgnoresAccessChecksToGenerator.Tasks.PublicizeInternals.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```

This crash can be reproduced by building the following project with `dotnet build`:

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net472</TargetFramework>
    <InternalsAssemblyNames>Oracle.ManagedDataAccess</InternalsAssemblyNames>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.4.0" />
    <PackageReference Include="Oracle.ManagedDataAccess" Version="19.9.0" />
  </ItemGroup>
</Project>
```