### PR TITLE
Use `IntermediateOutputPath` instead of blindly guessing that it's `obj/`

### DIFF
--- a/src/Build/IgnoresAccessChecksToGenerator.targets
+++ b/src/Build/IgnoresAccessChecksToGenerator.targets
@@ -9,7 +9,12 @@
   <UsingTask AssemblyFile="$(_IACTG_TaskAssembly)" TaskName="IgnoresAccessChecksToGenerator.Tasks.PublicizeInternals" />
 
   <Target Name="IgnoresAccessChecksToGenerator" AfterTargets="AfterResolveReferences">
-    <PublicizeInternals SourceReferences="@(ReferencePath)" AssemblyNames="$(InternalsAssemblyNames)" ExcludeTypeNames="$(InternalsAssemblyExcludeTypeNames)" UseEmptyMethodBodies="$(InternalsAssemblyUseEmptyMethodBodies)">
+    <PublicizeInternals 
+      SourceReferences="@(ReferencePath)"
+      AssemblyNames="$(InternalsAssemblyNames)"
+      ExcludeTypeNames="$(InternalsAssemblyExcludeTypeNames)"
+      UseEmptyMethodBodies="$(InternalsAssemblyUseEmptyMethodBodies)"
+      IntermediateOutputDirectory="$(IntermediateOutputDirectory)">
       <Output ItemName="ReferencePath" TaskParameter="TargetReferences" />
       <Output ItemName="_IACTG_RemovedReferences" TaskParameter="RemovedReferences" />
       <Output ItemName="Compile" TaskParameter="GeneratedCodeFiles" />

--- a/src/Build/IgnoresAccessChecksToGenerator.targets
+++ b/src/Build/IgnoresAccessChecksToGenerator.targets
@@ -14,7 +14,7 @@
       AssemblyNames="$(InternalsAssemblyNames)"
       ExcludeTypeNames="$(InternalsAssemblyExcludeTypeNames)"
       UseEmptyMethodBodies="$(InternalsAssemblyUseEmptyMethodBodies)"
-      IntermediateOutputDirectory="$(IntermediateOutputDirectory)">
+      IntermediateOutputDirectory="$(IntermediateOutputPath)">
       <Output ItemName="ReferencePath" TaskParameter="TargetReferences" />
       <Output ItemName="_IACTG_RemovedReferences" TaskParameter="RemovedReferences" />
       <Output ItemName="Compile" TaskParameter="GeneratedCodeFiles" />

--- a/src/IgnoresAccessChecksToGenerator.Tasks/PublicizeInternals.cs
+++ b/src/IgnoresAccessChecksToGenerator.Tasks/PublicizeInternals.cs
@@ -12,8 +12,6 @@ namespace IgnoresAccessChecksToGenerator.Tasks
     {
         private static readonly char[] Semicolon = { ';' };
 
-        private readonly string _sourceDir = Directory.GetCurrentDirectory();
-
         private readonly AssemblyResolver _resolver = new AssemblyResolver();
 
         [Required]
@@ -21,6 +19,9 @@ namespace IgnoresAccessChecksToGenerator.Tasks
 
         [Required]
         public string AssemblyNames { get; set; }
+
+        [Required]
+        public string IntermediateOutputDirectory { get; set; }
 
         public string ExcludeTypeNames { get; set; }
 
@@ -48,7 +49,7 @@ namespace IgnoresAccessChecksToGenerator.Tasks
                 return true;
             }
 
-            var targetPath = Path.Combine(_sourceDir, "obj", "GeneratedPublicizedAssemblies");
+            var targetPath = Path.Combine(IntermediateOutputDirectory, "GeneratedPublicizedAssemblies");
             Directory.CreateDirectory(targetPath);
 
             GenerateAttributes(targetPath, assemblyNames);
@@ -175,11 +176,6 @@ namespace System.Runtime.CompilerServices
 
         private string GetFullFilePath(string path)
         {
-            if (!Path.IsPathRooted(path))
-            {
-                path = Path.Combine(_sourceDir, path);
-            }
-
             path = Path.GetFullPath(path);
             return path;
         }


### PR DESCRIPTION
Quite a lot of projects do not use the default intermediate output directory, instead moving it entirely out-of-band. This causes problems with this package, as it assumes that the intermediate output directory is the default, and MSBuild tries to load files generated by this as part of the project. 