### PR TITLE
#22: Save generated IgnoresAccessChecksTo.cs file with UTF8 encoding

### DIFF
--- a/src/IgnoresAccessChecksToGenerator.Tasks/PublicizeInternals.cs
+++ b/src/IgnoresAccessChecksToGenerator.Tasks/PublicizeInternals.cs
@@ -87,7 +87,7 @@ namespace System.Runtime.CompilerServices
         }
     }
 }";
-            File.WriteAllText(GeneratedCodeFilePath, content);
+            File.WriteAllText(GeneratedCodeFilePath, content, System.Text.Encoding.UTF8);
 
             Log.LogMessageFromText("Generated IgnoresAccessChecksTo attributes", MessageImportance.Low);
         }


### PR DESCRIPTION
Fixing StyleCop rule SA1412:
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md

Fixes #22 